### PR TITLE
Improvement: Display active connection name in front of Run SQL

### DIFF
--- a/package.nls.json
+++ b/package.nls.json
@@ -22,7 +22,7 @@
 	"command.runQuery": "Run Selected SQL",
 	"command.runAllQuery": "Run All SQL",
 	"command.util.github": "Star the project to represent support.",
-	"command.query.switch": "Open Query",
+	"command.query.switch": "Set Active",
 	"command.data.import": "Import Sql",
 	"command.data.export": "Export Data",
 	"command.document.generate": "Generate Document",

--- a/src/model/database/connectionNode.ts
+++ b/src/model/database/connectionNode.ts
@@ -127,21 +127,9 @@ export class ConnectionNode extends Node implements CopyAble {
 
     public async newQuery() {
 
-        await FileManager.show(`${this.label}.sql`);
-        let childMap = {};
-        const dbNameList = (await this.getChildren()).filter((databaseNode) => (databaseNode instanceof SchemaNode || databaseNode instanceof CatalogNode)).map((databaseNode) => {
-            childMap[databaseNode.uid] = databaseNode
-            return this.dbType == DatabaseType.MYSQL ? databaseNode.schema : databaseNode.database;
-        });
-        let dbName: string;
-        if (dbNameList.length == 1) {
-            dbName = dbNameList[0]
-        }
-        if (dbNameList.length > 1) {
-            dbName = await vscode.window.showQuickPick(dbNameList, { placeHolder: "active database" })
-        }
-        this.contextValue = ModelType.SCHEMA;
-        ConnectionManager.changeActive(dbName ? childMap[`${this.getConnectId()}@${dbName}`] : this)
+        
+        this.contextValue = ModelType.CONNECTION;
+        ConnectionManager.changeActive( this)
 
     }
 

--- a/src/model/database/schemaNode.ts
+++ b/src/model/database/schemaNode.ts
@@ -110,7 +110,6 @@ export class SchemaNode extends Node implements CopyAble {
 
     public async newQuery() {
 
-        QueryUnit.showSQLTextDocument(this,'',`${this.schema}.sql`,FileModel.APPEND);
         ConnectionManager.changeActive(this);
 
     }

--- a/src/model/interface/node.ts
+++ b/src/model/interface/node.ts
@@ -105,6 +105,7 @@ export abstract class Node extends vscode.TreeItem implements CopyAble {
     }
 
     protected init(source: Node) {
+        this.name = source.name
         this.host = source.host
         this.port = source.port
         this.user = source.user

--- a/src/vue/connect/index.vue
+++ b/src/vue/connect/index.vue
@@ -325,6 +325,7 @@ export default {
         dbPath: "",
         port: "47335",
         user: "mindsdb",
+        requestTimeout: 10000,
         authType: "default",
         password: "",
         encoding: "utf8",


### PR DESCRIPTION
1. Changed the New Query to Set Active. It will prevent opening a new sql file, instead it will just make the current connection as active connection 2. In the sql file it will now display the connection name in front of Run SQL action